### PR TITLE
 Fix book meta speed for enchantments

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Get PR info
-        run: echo ::set-env name=PR::$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+        run: |
+          echo "PR=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')" >> $GITHUB_ENV
 
       - name: Set up JDK 8
         uses: actions/setup-java@v1

--- a/patches/server/0042-Improve-merge-checks.patch
+++ b/patches/server/0042-Improve-merge-checks.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: AlexProgrammerDE <40795980+AlexProgrammerDE@users.noreply.github.com>
+Date: Sat, 7 May 2022 20:09:43 +0200
+Subject: [PATCH] Improve merge checks
+
+
+diff --git a/src/main/java/dev/pomf/dionysus/DionysusConfig.java b/src/main/java/dev/pomf/dionysus/DionysusConfig.java
+index f078bbd9c9dd1447129c8d95314a514d8969471d..8e0597a01e7f6b7926ac0632a6e6449d69d38a86 100644
+--- a/src/main/java/dev/pomf/dionysus/DionysusConfig.java
++++ b/src/main/java/dev/pomf/dionysus/DionysusConfig.java
+@@ -279,6 +279,9 @@ public class DionysusConfig {
+         optimizeArmourStands = getBoolean("optimize-armourstands", optimizeArmourStands);
+     }
+ 
+-
++    public static boolean improveMergeChecks = true;
++    private static void improveMergeChecks() {
++        improveMergeChecks = getBoolean("improve-merge-checks", improveMergeChecks);
++    }
+ 
+ }
+diff --git a/src/main/java/net/minecraft/server/PlayerInventory.java b/src/main/java/net/minecraft/server/PlayerInventory.java
+index 84f59b7501b111a3af551f3bcdf2d80fc35f89b1..d590aedf7f9659b57dd1ca8ad7f7a2db815f3b58 100644
+--- a/src/main/java/net/minecraft/server/PlayerInventory.java
++++ b/src/main/java/net/minecraft/server/PlayerInventory.java
+@@ -8,6 +8,8 @@ import javax.annotation.Nullable;
+ // CraftBukkit start
+ import java.util.ArrayList;
+ import java.util.List;
++
++import dev.pomf.dionysus.DionysusConfig;
+ import org.bukkit.Location;
+ 
+ import org.bukkit.craftbukkit.entity.CraftHumanEntity;
+@@ -86,6 +88,12 @@ public class PlayerInventory implements IInventory {
+     }
+ 
+     private boolean a(ItemStack itemstack, ItemStack itemstack1) {
++        // Dionysus start
++        if (DionysusConfig.improveMergeChecks) {
++            return !itemstack.isEmpty() && itemstack.isStackable() && itemstack.getCount() < itemstack.getMaxStackSize() && itemstack.getCount() < this.getMaxStackSize() && this.b(itemstack, itemstack1);
++        }
++        // Dionysus end
++
+         return !itemstack.isEmpty() && this.b(itemstack, itemstack1) && itemstack.isStackable() && itemstack.getCount() < itemstack.getMaxStackSize() && itemstack.getCount() < this.getMaxStackSize();
+     }
+ 
+@@ -265,6 +273,12 @@ public class PlayerInventory implements IInventory {
+     }
+ 
+     public int firstPartial(ItemStack itemstack) {
++        // Dionysus start
++        if (DionysusConfig.improveMergeChecks && !itemstack.isStackable()) {
++            return -1;
++        }
++        // Dionysus end
++
+         if (this.a(this.getItem(this.itemInHandIndex), itemstack)) {
+             return this.itemInHandIndex;
+         } else if (this.a(this.getItem(40), itemstack)) {

--- a/patches/server/0043-Fix-book-meta-speed-for-enchantments.patch
+++ b/patches/server/0043-Fix-book-meta-speed-for-enchantments.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: AlexProgrammerDE <40795980+AlexProgrammerDE@users.noreply.github.com>
+Date: Mon, 6 Jun 2022 18:24:13 +0200
+Subject: [PATCH] Fix book meta speed for enchantments
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+index decdccdc76a09c1da62aef6d4d4542b92242788b..b093e81eb9e1db5dec08cfa12b7b5da141e817d2 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+@@ -236,7 +236,7 @@ public final class CraftItemStack extends ItemStack {
+ 
+     @Override
+     public Map<Enchantment, Integer> getEnchantments() {
+-        return hasItemMeta() ? getItemMeta().getEnchants() : ImmutableMap.<Enchantment, Integer>of(); // Paper - use Item Meta
++        return hasItemMeta() ? getItemMeta(handle, false).getEnchants() : ImmutableMap.<Enchantment, Integer>of(); // Paper - use Item Meta // Dionysus - Increase Book Meta Performance
+     }
+ 
+     static Map<Enchantment, Integer> getEnchantments(net.minecraft.server.ItemStack item) {
+@@ -276,15 +276,21 @@ public final class CraftItemStack extends ItemStack {
+         return getItemMeta(handle);
+     }
+ 
++    // Dionysus start - Increase Book Meta Performance
+     public static ItemMeta getItemMeta(net.minecraft.server.ItemStack item) {
++        return getItemMeta(item, true);
++    }
++    // Dionysus end
++
++    public static ItemMeta getItemMeta(net.minecraft.server.ItemStack item, boolean resolveFurther) { // Dionysus - Increase Book Meta Performance
+         if (!hasItemMeta(item)) {
+             return CraftItemFactory.instance().getItemMeta(getType(item));
+         }
+         switch (getType(item)) {
+             case WRITTEN_BOOK:
+-                return new CraftMetaBookSigned(item.getTag());
++                return new CraftMetaBookSigned(item.getTag(), resolveFurther); // Dionysus - Increase Book Meta Performance
+             case BOOK_AND_QUILL:
+-                return new CraftMetaBook(item.getTag());
++                return new CraftMetaBook(item.getTag(), resolveFurther); // Dionysus - Increase Book Meta Performance
+             case SKULL_ITEM:
+                 return new CraftMetaSkull(item.getTag());
+             case LEATHER_HELMET:
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
+index bffbe9013bbe5d60295f4b8d9f84b21eb1942f4a..67d43cb19f07353dae5b97f5c0d0f3495f560def 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
+@@ -23,7 +23,13 @@ class CraftMetaBookSigned extends CraftMetaBook implements BookMeta {
+         super(meta);
+     }
+ 
++    // // Dionysus start - Increase Book Meta Performance
+     CraftMetaBookSigned(NBTTagCompound tag) {
++        this(tag, true);
++    }
++    // Dionysus end
++
++    CraftMetaBookSigned(NBTTagCompound tag, boolean handlePages) { // Dionysus - Increase Book Meta Performance
+         super(tag, false);
+ 
+         boolean resolved = true;
+@@ -31,7 +37,7 @@ class CraftMetaBookSigned extends CraftMetaBook implements BookMeta {
+             resolved = tag.getBoolean(RESOLVED.NBT);
+         }
+ 
+-        if (tag.hasKey(BOOK_PAGES.NBT)) {
++        if (tag.hasKey(BOOK_PAGES.NBT) && handlePages) { // Dionysus - Increase Book Meta Performance
+             NBTTagList pages = tag.getList(BOOK_PAGES.NBT, CraftMagicNumbers.NBT.TAG_STRING);
+ 
+             for (int i = 0; i < Math.min(pages.size(), MAX_PAGES); i++) {

--- a/patches/server/0044-Add-option-to-disable-chunk-loading-past-the-world-b.patch
+++ b/patches/server/0044-Add-option-to-disable-chunk-loading-past-the-world-b.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: AlexProgrammerDE <40795980+AlexProgrammerDE@users.noreply.github.com>
+Date: Fri, 10 Jun 2022 19:12:12 +0200
+Subject: [PATCH] Add option to disable chunk loading past the world border
+
+
+diff --git a/src/main/java/dev/pomf/dionysus/DionysusConfig.java b/src/main/java/dev/pomf/dionysus/DionysusConfig.java
+index 8e0597a01e7f6b7926ac0632a6e6449d69d38a86..1e2bb1c5095a1d99419c324286494df26f38453d 100644
+--- a/src/main/java/dev/pomf/dionysus/DionysusConfig.java
++++ b/src/main/java/dev/pomf/dionysus/DionysusConfig.java
+@@ -284,4 +284,9 @@ public class DionysusConfig {
+         improveMergeChecks = getBoolean("improve-merge-checks", improveMergeChecks);
+     }
+ 
++    public static boolean noChunksPastWorldBorder = true;
++    private static void noChunksPastWorldBorder() {
++        noChunksPastWorldBorder = getBoolean("no-chunks-past-world-border", noChunksPastWorldBorder);
++    }
++
+ }
+diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
+index 71906caa0b229217eac7404ccba0453e96624d0f..b40c136fae6e3e5b8bd706cfaeea2e5aedad2b05 100644
+--- a/src/main/java/net/minecraft/server/PlayerChunk.java
++++ b/src/main/java/net/minecraft/server/PlayerChunk.java
+@@ -64,6 +64,7 @@ public class PlayerChunk {
+         if (this.c.contains(entityplayer)) {
+             PlayerChunk.a.debug("Failed to add player. {} already is in chunk {}, {}", entityplayer, Integer.valueOf(this.location.x), Integer.valueOf(this.location.z));
+         } else {
++            if (!dev.pomf.dionysus.DionysusConfig.noChunksPastWorldBorder || playerChunkMap.getWorld().getWorldBorder().isChunkInBounds(location.x, location.z)) { // Dionysus
+             if (this.c.isEmpty()) {
+                 this.i = this.playerChunkMap.getWorld().getTime();
+             }
+@@ -77,7 +78,7 @@ public class PlayerChunk {
+                 this.sendChunk(entityplayer);
+             }
+             // CraftBukkit end
+-
++            }
+         }
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/WorldBorder.java b/src/main/java/net/minecraft/server/WorldBorder.java
+index 1bb172bbf7d2f69bcdc36265f55e9d4f359a41ec..f404894d56c89a5a085e48e2b4199edae9a86ddd 100644
+--- a/src/main/java/net/minecraft/server/WorldBorder.java
++++ b/src/main/java/net/minecraft/server/WorldBorder.java
+@@ -36,10 +36,12 @@ public class WorldBorder {
+     // Paper start
+     private final BlockPosition.MutableBlockPosition mutPos = new BlockPosition.MutableBlockPosition();
+     public boolean isBlockInBounds(int chunkX, int chunkZ) {
++        BlockPosition.MutableBlockPosition mutPos = new BlockPosition.MutableBlockPosition(); // Dionysus - avoid collisions with other threads
+         mutPos.setValues(chunkX, 64, chunkZ);
+         return isInBounds(mutPos);
+     }
+     public boolean isChunkInBounds(int chunkX, int chunkZ) {
++        BlockPosition.MutableBlockPosition mutPos = new BlockPosition.MutableBlockPosition(); // Dionysus - avoid collisions with other threads
+         mutPos.setValues(((chunkX << 4) + 15), 64, (chunkZ << 4) + 15);
+         return isInBounds(mutPos);
+     }

--- a/patches/server/0045-Disable-JNDI-lookups-in-the-default-log-config.patch
+++ b/patches/server/0045-Disable-JNDI-lookups-in-the-default-log-config.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: AlexProgrammerDE <40795980+AlexProgrammerDE@users.noreply.github.com>
+Date: Fri, 10 Jun 2022 19:28:11 +0200
+Subject: [PATCH] Disable JNDI lookups in the default log config
+
+
+diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
+index 6711e6dff9ca15a516003e79b4882794b7a73644..2024f99bc838cd3261893a1c782c5d2c9553f283 100644
+--- a/src/main/resources/log4j2.xml
++++ b/src/main/resources/log4j2.xml
+@@ -3,21 +3,21 @@
+     <Appenders>
+         <TerminalConsole name="TerminalConsole">
+             <PatternLayout>
+-                <LoggerNamePatternSelector defaultPattern="%highlightError{[%d{HH:mm:ss} %level]: [%logger] %minecraftFormatting{%msg}%n%xEx}">
++                <LoggerNamePatternSelector defaultPattern="%highlightError{[%d{HH:mm:ss} %level]: [%logger] %minecraftFormatting{%msg{nolookups}}%n%xEx}">
+                     <!-- Log root, Minecraft, Mojang and Bukkit loggers without prefix -->
+                     <!-- Disable prefix for various plugins that bypass the plugin logger -->
+                     <PatternMatch key=",net.minecraft.,Minecraft,com.mojang.,com.sk89q.,ru.tehkode.,Minecraft.AWE"
+-                                  pattern="%highlightError{[%d{HH:mm:ss} %level]: %minecraftFormatting{%msg}%n%xEx}" />
++                                  pattern="%highlightError{[%d{HH:mm:ss} %level]: %minecraftFormatting{%msg{nolookups}}%n%xEx}" />
+                 </LoggerNamePatternSelector>
+             </PatternLayout>
+         </TerminalConsole>
+         <RollingRandomAccessFile name="File" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
+             <PatternLayout>
+-                <LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss}] [%t/%level]: [%logger] %minecraftFormatting{%msg}{strip}%n">
++                <LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss}] [%t/%level]: [%logger] %minecraftFormatting{%msg{nolookups}}{strip}%n">
+                     <!-- Log root, Minecraft, Mojang and Bukkit loggers without prefix -->
+                     <!-- Disable prefix for various plugins that bypass the plugin logger -->
+                     <PatternMatch key=",net.minecraft.,Minecraft,com.mojang.,com.sk89q.,ru.tehkode.,Minecraft.AWE"
+-                                  pattern="[%d{HH:mm:ss}] [%t/%level]: %minecraftFormatting{%msg}{strip}%n" />
++                                  pattern="[%d{HH:mm:ss}] [%t/%level]: %minecraftFormatting{%msg{nolookups}}{strip}%n" />
+                 </LoggerNamePatternSelector>
+             </PatternLayout>
+             <Policies>

--- a/patches/server/0046-Improve-performance-of-book-meta-pages.patch
+++ b/patches/server/0046-Improve-performance-of-book-meta-pages.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Improve performance of book meta pages
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-index ffdb7ec8290c035fa0dea92622fbdd9a9cd9cd50..250eb093e19ee6befcd32ffe31bfe0f305f698b6 100644
+index ffdb7ec8290c035fa0dea92622fbdd9a9cd9cd50..52b22d2cf3786e8f01591a5ecbcc65acef469e45 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 @@ -30,6 +30,11 @@ import net.md_5.bungee.chat.ComponentSerializer;
@@ -26,7 +26,7 @@ index ffdb7ec8290c035fa0dea92622fbdd9a9cd9cd50..250eb093e19ee6befcd32ffe31bfe0f3
      protected String author;
 -    public List<IChatBaseComponent> pages = new ArrayList<IChatBaseComponent>();
 +    // Dionysus start - Increase Book Page Performance
-+    enum PageType {RESOLVED, UNRESOLVED}
++    protected enum PageType {RESOLVED, UNRESOLVED}
 +    protected final List<Pair<PageType, String>> pagePreStore = new ArrayList<>();
 +    public List<IChatBaseComponent> pages = new ForwardingList<IChatBaseComponent>() {
 +        private List<IChatBaseComponent> delegate;
@@ -74,15 +74,26 @@ index ffdb7ec8290c035fa0dea92622fbdd9a9cd9cd50..250eb093e19ee6befcd32ffe31bfe0f3
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
-index 549093c182faf45032442d1d62b87d1c7dcb896c..c8c6a2b2e2408eabfc0b34ec72e2e49b0d8bba72 100644
+index 549093c182faf45032442d1d62b87d1c7dcb896c..65a2957beb032fdd9d2c35ef958b1fe649becc79 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
-@@ -44,7 +44,7 @@ class CraftMetaBookSigned extends CraftMetaBook implements BookMeta {
+@@ -16,6 +16,10 @@ import net.minecraft.server.IChatBaseComponent.ChatSerializer;
+ import net.minecraft.server.IChatBaseComponent;
+ import net.minecraft.server.NBTTagString;
+ 
++// Dionysus start
++import org.apache.commons.lang3.tuple.Pair;
++// Dionysus end
++
+ @DelegateDeserialization(SerializableMeta.class)
+ class CraftMetaBookSigned extends CraftMetaBook implements BookMeta {
+ 
+@@ -44,7 +48,7 @@ class CraftMetaBookSigned extends CraftMetaBook implements BookMeta {
                  String page = pages.getString(i);
                  if (resolved) {
                      try {
 -                        this.pages.add(ChatSerializer.a(page));
-+                        this.pagePreStore.add(page); // Dionysus - Increase Book Page Performance
++                        this.pagePreStore.add(Pair.of(PageType.RESOLVED, page)); // Dionysus - Increase Book Page Performance
                          continue;
                      } catch (Exception e) {
                          // Ignore and treat as an old book

--- a/patches/server/0046-Improve-performance-of-book-meta-pages.patch
+++ b/patches/server/0046-Improve-performance-of-book-meta-pages.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Improve performance of book meta pages
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-index ffdb7ec8290c035fa0dea92622fbdd9a9cd9cd50..71b88d00e71fec3c92c6b8f2430461b0ff9ba8d6 100644
+index ffdb7ec8290c035fa0dea92622fbdd9a9cd9cd50..250eb093e19ee6befcd32ffe31bfe0f305f698b6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 @@ -30,6 +30,11 @@ import net.md_5.bungee.chat.ComponentSerializer;
@@ -69,7 +69,7 @@ index ffdb7ec8290c035fa0dea92622fbdd9a9cd9cd50..71b88d00e71fec3c92c6b8f2430461b0
              }
  
 -            this.pages.add(CraftChatMessage.fromString(page, true)[0]);
-+            pagePreStore.add(Pair.of(PageType.UNRESOLVED, page)); // Dionysus start - Increase Book Page Performance
++            this.pagePreStore.add(Pair.of(PageType.UNRESOLVED, page)); // Dionysus - Increase Book Page Performance
          }
      }
  

--- a/patches/server/0046-Improve-performance-of-book-meta-pages.patch
+++ b/patches/server/0046-Improve-performance-of-book-meta-pages.patch
@@ -5,43 +5,74 @@ Subject: [PATCH] Improve performance of book meta pages
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-index ffdb7ec8290c035fa0dea92622fbdd9a9cd9cd50..ee64406440ef5b0d81b64dfb12c49ca269a7943c 100644
+index ffdb7ec8290c035fa0dea92622fbdd9a9cd9cd50..71b88d00e71fec3c92c6b8f2430461b0ff9ba8d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-@@ -44,7 +44,23 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -30,6 +30,11 @@ import net.md_5.bungee.chat.ComponentSerializer;
+ import net.minecraft.server.ChatBaseComponent;
+ // Spigot end
+ 
++// Dionysus start
++import com.google.common.collect.ForwardingList;
++import org.apache.commons.lang3.tuple.Pair;
++// Dionysus end
++
+ @DelegateDeserialization(SerializableMeta.class)
+ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+     static final ItemMetaKey BOOK_TITLE = new ItemMetaKey("title");
+@@ -44,7 +49,33 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
  
      protected String title;
      protected String author;
 -    public List<IChatBaseComponent> pages = new ArrayList<IChatBaseComponent>();
 +    // Dionysus start - Increase Book Page Performance
-+    protected final List<String> pagePreStore = new ArrayList<>();
-+    public List<IChatBaseComponent> pages = new com.google.common.collect.ForwardingList<IChatBaseComponent>() {
++    enum PageType {RESOLVED, UNRESOLVED}
++    protected final List<Pair<PageType, String>> pagePreStore = new ArrayList<>();
++    public List<IChatBaseComponent> pages = new ForwardingList<IChatBaseComponent>() {
 +        private List<IChatBaseComponent> delegate;
 +        @Override
 +        protected synchronized List<IChatBaseComponent> delegate() {
 +            if (delegate == null) {
 +                List<IChatBaseComponent> list = new ArrayList<>();
-+                for (String page : pagePreStore) {
-+                    list.add(ChatSerializer.a(page));
++                for (Pair<PageType, String> page : pagePreStore) {
++                    if (page.getLeft() == PageType.RESOLVED) {
++                        list.add(ChatSerializer.a(page.getRight()));
++                    } else if (page.getLeft() == PageType.UNRESOLVED) {
++                        list.add(CraftChatMessage.fromString(page.getRight(), true)[0]);
++                    }
 +                }
 +                delegate = list;
 +            }
 +            return delegate;
++        }
++
++        @Override
++        public int size() {
++            return pagePreStore.size();
 +        }
 +    };
 +    // Dionysus end
      protected Integer generation;
  
      CraftMetaBook(CraftMetaItem meta) {
-@@ -90,7 +106,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -90,7 +121,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
                  String page = pages.getString(i);
                  if (resolved) {
                      try {
 -                        this.pages.add(ChatSerializer.a(page));
-+                        this.pagePreStore.add(page); // Dionysus - Increase Book Page Performance
++                        this.pagePreStore.add(Pair.of(PageType.RESOLVED, page)); // Dionysus - Increase Book Page Performance
                          continue;
                      } catch (Exception e) {
                          // Ignore and treat as an old book
+@@ -255,7 +286,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+                 page = page.substring(0, MAX_PAGE_LENGTH);
+             }
+ 
+-            this.pages.add(CraftChatMessage.fromString(page, true)[0]);
++            pagePreStore.add(Pair.of(PageType.UNRESOLVED, page)); // Dionysus start - Increase Book Page Performance
+         }
+     }
+ 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
 index 549093c182faf45032442d1d62b87d1c7dcb896c..c8c6a2b2e2408eabfc0b34ec72e2e49b0d8bba72 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java

--- a/patches/server/0046-Improve-performance-of-book-meta-pages.patch
+++ b/patches/server/0046-Improve-performance-of-book-meta-pages.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: AlexProgrammerDE <40795980+AlexProgrammerDE@users.noreply.github.com>
+Date: Sat, 11 Jun 2022 07:41:54 +0200
+Subject: [PATCH] Improve performance of book meta pages
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
+index ffdb7ec8290c035fa0dea92622fbdd9a9cd9cd50..ee64406440ef5b0d81b64dfb12c49ca269a7943c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
+@@ -44,7 +44,23 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+ 
+     protected String title;
+     protected String author;
+-    public List<IChatBaseComponent> pages = new ArrayList<IChatBaseComponent>();
++    // Dionysus start - Increase Book Page Performance
++    protected final List<String> pagePreStore = new ArrayList<>();
++    public List<IChatBaseComponent> pages = new com.google.common.collect.ForwardingList<IChatBaseComponent>() {
++        private List<IChatBaseComponent> delegate;
++        @Override
++        protected synchronized List<IChatBaseComponent> delegate() {
++            if (delegate == null) {
++                List<IChatBaseComponent> list = new ArrayList<>();
++                for (String page : pagePreStore) {
++                    list.add(ChatSerializer.a(page));
++                }
++                delegate = list;
++            }
++            return delegate;
++        }
++    };
++    // Dionysus end
+     protected Integer generation;
+ 
+     CraftMetaBook(CraftMetaItem meta) {
+@@ -90,7 +106,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+                 String page = pages.getString(i);
+                 if (resolved) {
+                     try {
+-                        this.pages.add(ChatSerializer.a(page));
++                        this.pagePreStore.add(page); // Dionysus - Increase Book Page Performance
+                         continue;
+                     } catch (Exception e) {
+                         // Ignore and treat as an old book
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
+index 549093c182faf45032442d1d62b87d1c7dcb896c..c8c6a2b2e2408eabfc0b34ec72e2e49b0d8bba72 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
+@@ -44,7 +44,7 @@ class CraftMetaBookSigned extends CraftMetaBook implements BookMeta {
+                 String page = pages.getString(i);
+                 if (resolved) {
+                     try {
+-                        this.pages.add(ChatSerializer.a(page));
++                        this.pagePreStore.add(page); // Dionysus - Increase Book Page Performance
+                         continue;
+                     } catch (Exception e) {
+                         // Ignore and treat as an old book


### PR DESCRIPTION
Every single page in the book meta gets converted just for getting enchantments. That's inefficient.