### PR TITLE
dirty workaround for the download issue

### DIFF
--- a/scripts/upstream.sh
+++ b/scripts/upstream.sh
@@ -20,6 +20,22 @@ if [[ "$1" == up* ]]; then
 fi
 
 paperVer=$(gethead Paper)
+
+minecraftserverurl=$(cat "$basedir"/Paper/work/BuildData/info.json | grep serverUrl | cut -d '"' -f 4)
+minecraftversion=$(cat "$basedir"/Paper/work/BuildData/info.json | grep minecraftVersion | cut -d '"' -f 4)
+decompiledir="$basedir/Paper/work/Minecraft/$minecraftversion"
+jarpath="$decompiledir/$minecraftversion"
+
+if [ ! -f  "$jarpath.jar" ]; then
+    echo "Downloading unmapped vanilla jar..."
+    mkdir -p "$decompiledir"
+    curl -s -o "$jarpath.jar" "$minecraftserverurl"
+    if [ "$?" != "0" ]; then
+        echo "Failed to download the vanilla server jar. Check connectivity or try again later."
+        exit 1
+    fi
+fi
+
 cd "$basedir/Paper/"
 
 ./paper patch
@@ -30,7 +46,6 @@ mcVer=$(mvn -o org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpre
 basedir
 . $basedir/scripts/importmcdev.sh
 
-minecraftversion=$(cat "$basedir"/Paper/work/BuildData/info.json | grep minecraftVersion | cut -d '"' -f 4)
 version=$(echo -e "Paper: $paperVer\nmc-dev:$importedmcdev")
 tag="${minecraftversion}-${mcVer}-$(echo -e $version | shasum | awk '{print $1}')"
 echo "$tag" > "$basedir"/current-paper


### PR DESCRIPTION
[the download URL](https://s3.amazonaws.com/Minecraft.Download) in Paper 1.12.2 build script became defective, causing build issues
this commit "fix" that (tho kinda bulky) by directly download from mojang's server

hunk copied over from [Paper 1.16.5's remap.sh](https://github.com/PaperMC/Paper/blob/ver/1.16.5/scripts/remap.sh#L9)